### PR TITLE
For some reason on Windows 10 the NullDevice class approach...

### DIFF
--- a/src/lib/marble/MarbleDebug.cpp
+++ b/src/lib/marble/MarbleDebug.cpp
@@ -10,29 +10,13 @@
 
 #include "MarbleDebug.h"
 
+#include <QFile>
+#include <QProcess>
+
 namespace Marble
 {
 // bool MarbleDebug::m_enabled = true;
 bool MarbleDebug::m_enabled = false;
-
-class NullDevice : public QIODevice
-{
-public:
-    NullDevice()
-    {
-        open( QIODevice::WriteOnly );
-    }
-
-    qint64 readData( char * /*data*/, qint64 /*maxSize*/ )
-    {
-        return -1;
-    }
-
-    qint64 writeData( const char * /*data*/, qint64 maxSize )
-    {
-        return maxSize;
-    }
-};
 
 QDebug mDebug()
 {
@@ -40,8 +24,10 @@ QDebug mDebug()
         return QDebug( QtDebugMsg );
     }
     else {
-        static QIODevice *device = new NullDevice;
-        return QDebug( device );
+        static QFile *nullDevice = new QFile(QProcess::nullDevice());
+        if ( !nullDevice->isOpen() )
+             nullDevice->open(QIODevice::WriteOnly);
+         return QDebug( nullDevice );
     }
 }
 


### PR DESCRIPTION
causes an infinite loop because QtCore cannot obtain a mutex lock
(ntdll.dll!_NtWaitForSingleObject) for the text stream.

Using this method of passing the location of the system null device
to QFile, "should" work better.

This is Lubomirs fix from the mailing list for my Subsurface freezes during startup on Windows issue plus a small merge confict fix from me plus putting it in a Github pull request.
Status:
- Compiles: yes
- Runs with MXE windows build: yes
- Fixes the problem: ~50% sure but need further testing on my PC at home